### PR TITLE
Syntax work

### DIFF
--- a/HLSL.sublime-syntax
+++ b/HLSL.sublime-syntax
@@ -165,7 +165,7 @@ contexts:
     - match: //
       push:
         - meta_scope: comment.line.double-slash.hlsl
-        - match: $
+        - match: \n
           pop: true
 
 
@@ -210,15 +210,14 @@ contexts:
 
 
   function_macro_body:
-    - match: \)[ \t]*\n
-      pop: true
     - include: prototype
     - meta_content_scope: meta.function.parameters.hlsl
     - match: \)
       set:
         - meta_scope: meta.function.hlsl
         - include: prototype
-        - include: preprocessor_multiline_ending
+        - include: preprocessor_line_continuation
+        - include: preprocessor_line_ending
 
 
   intrinsics:
@@ -429,13 +428,12 @@ contexts:
       scope: keyword.control.preprocessor.hlsl
 
 
+  preprocessor_line_continuation:
+    - match: (\\)$\n
+
+
   preprocessor_line_ending:
     - match: $\n
-      pop: true
-
-
-  preprocessor_multiline_ending:
-    - match: '[^\\]$\n'
       pop: true
 
 
@@ -455,7 +453,8 @@ contexts:
       push:
         - meta_scope: meta.preprocessor.hlsl
         - include: prototype
-        - include: preprocessor_multiline_ending
+        - include: preprocessor_line_continuation
+        - include: preprocessor_line_ending
 
     - match: (#if[n]*def)(?:\s+)({{valid_variable}})
       captures:

--- a/Tests/syntax_test_hlsl_functions.fx
+++ b/Tests/syntax_test_hlsl_functions.fx
@@ -6,6 +6,9 @@
 //        ^^^^^^^^^^^^^^ entity.name.function.hlsl
 //^^^^^^^^ -entity.name.function.hlsl
 //                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ -entity.name.function.hlsl
+//                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.hlsl
+
+//^ -meta.function.hlsl
 
   #define MACRO_FUNCTION(param1, param2) \
 //        ^^^^^^^^^^^^^^ entity.name.function.hlsl

--- a/Tests/syntax_test_hlsl_preprocessor.fx
+++ b/Tests/syntax_test_hlsl_preprocessor.fx
@@ -11,12 +11,28 @@
 //              ^^^^^^ storage.type.vector.hlsl
 //^^^^^^^^^^^^^^ -storage.type.vector.hlsl
 //                    ^^^^^^^^^^^^^^^^^^ -storage.type.vector.hlsl
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.hlsl
+
+//^ -meta.preprocessor.hlsl
 
   #define TOKEN
 //^^^^^^^ keyword.control.preprocessor.hlsl
 //       ^^^^^^ -keyword.control.preprocessor.hlsl
 //        ^^^^^ constant.other.hlsl
 //^^^^^^^^ -constant.other.hlsl
+//^^^^^^^^^^^^^ meta.preprocessor.hlsl
+
+//^ -meta.preprocessor.hlsl
+
+  #define TOKEN \
+//^^^^^^^ keyword.control.preprocessor.hlsl
+//       ^^^^^^ -keyword.control.preprocessor.hlsl
+//        ^^^^^ constant.other.hlsl
+//^^^^^^^^ -constant.other.hlsl
+    float3(0.0f, 1.0f, 0.0f)
+//^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.hlsl
+
+//^ -meta.preprocessor.hlsl
 
   #if defined(TOKEN)
 //^^^ keyword.control.preprocessor.hlsl
@@ -35,6 +51,8 @@
 //                ^^^^^^ storage.type.vector.hlsl
 //  ^^^^^^^^^^^^^^ -storage.type.vector.hlsl
 //                      ^^^^^^^^^^^^^^^^^^ -storage.type.vector.hlsl
+
+//^ -meta.preprocessor.hlsl
   #endif
 //^^^^^^ keyword.control.preprocessor.hlsl
 
@@ -53,6 +71,8 @@
 //                ^^^^^^ storage.type.vector.hlsl
 //  ^^^^^^^^^^^^^^ -storage.type.vector.hlsl
 //                      ^^^^^^^^^^^^^^^^^^ -storage.type.vector.hlsl
+
+//^ -meta.preprocessor.hlsl
   #endif
 //^^^^^^ keyword.control.preprocessor.hlsl
 
@@ -71,6 +91,8 @@
 //                ^^^^^^ storage.type.vector.hlsl
 //  ^^^^^^^^^^^^^^ -storage.type.vector.hlsl
 //                      ^^^^^^^^^^^^^^^^^^ -storage.type.vector.hlsl
+
+//^ -meta.preprocessor.hlsl
   #endif
 //^^^^^^ keyword.control.preprocessor.hlsl
 }

--- a/Tests/syntax_test_hlsl_preprocessor.fx
+++ b/Tests/syntax_test_hlsl_preprocessor.fx
@@ -15,6 +15,16 @@
 
 //^ -meta.preprocessor.hlsl
 
+  #define TOKEN 8
+//^^^^^^^ keyword.control.preprocessor.hlsl
+//       ^^^^^^ -keyword.control.preprocessor.hlsl
+//        ^^^^^ constant.other.hlsl
+//^^^^^^^^ -constant.other.hlsl
+//              ^ constant.numeric.hlsl
+//^^^^^^^^^^^^^^^ meta.preprocessor.hlsl
+
+//^ -meta.preprocessor.hlsl
+
   #define TOKEN
 //^^^^^^^ keyword.control.preprocessor.hlsl
 //       ^^^^^^ -keyword.control.preprocessor.hlsl


### PR DESCRIPTION
Change end of comment detection and end of macro line detection.  Fixes my outstanding bug with non-closing preprocessor metascope.