### PR TITLE
Don't pop function metascope due to extra braces

### DIFF
--- a/HLSL.sublime-syntax
+++ b/HLSL.sublime-syntax
@@ -206,15 +206,15 @@ contexts:
     - match: \)
       set:
         - meta_scope: meta.function.hlsl
-        - match: \}
-          scope: punctuation.section.block.end.hlsl
-          pop: true
         - match: \{
-        - include: prototype
           scope: punctuation.section.block.begin.hlsl
-          push:
-            - match: (?=\})
-              pop: true
+          set:
+          - meta_scope: meta.function.hlsl
+          - include: prototype
+          - include: empty_scope
+          - match: \}
+            scope: punctuation.section.block.end.hlsl
+            pop: true
 
 
   function_macro_body:


### PR DESCRIPTION
This should be the fix to #41.

Back up to all tests passing.  But mostly because my coverage still
isn't great.