### PR TITLE
Fix comment scope bug after function params

### DIFF
--- a/HLSL.sublime-syntax
+++ b/HLSL.sublime-syntax
@@ -205,6 +205,7 @@ contexts:
     - meta_content_scope: meta.function.parameters.hlsl
     - match: \)
       set:
+        - include: comments
         - meta_scope: meta.function.hlsl
         - match: \{
           scope: punctuation.section.block.begin.hlsl


### PR DESCRIPTION
Accidentally broke this with the last change.  This also works if I
include prototype instead of comments, but I don't think anything else
can legally appear between the param list and the body scope open.