### PR TITLE
Macro EOL without backslash always pops metascope

### DIFF
--- a/HLSL.sublime-syntax
+++ b/HLSL.sublime-syntax
@@ -174,10 +174,19 @@ contexts:
       scope: keyword.control.hlsl
 
 
-  empty_scope:
+  empty_scope_function:
     - match: \{
       push:
         - include: prototype
+        - match: \}
+          pop: true
+
+
+  empty_scope_macro:
+    - match: \{
+      push:
+        - include: prototype
+        - include: preprocessor_line_ending
         - match: \}
           pop: true
 
@@ -212,7 +221,7 @@ contexts:
           set:
           - meta_scope: meta.function.hlsl
           - include: prototype
-          - include: empty_scope
+          - include: empty_scope_function
           - match: \}
             scope: punctuation.section.block.end.hlsl
             pop: true
@@ -227,7 +236,7 @@ contexts:
         - include: prototype
         - include: preprocessor_line_continuation
         - include: preprocessor_line_ending
-        - include: empty_scope
+        - include: empty_scope_macro
 
 
   intrinsics:

--- a/Tests/syntax_test_hlsl_misc.fx
+++ b/Tests/syntax_test_hlsl_misc.fx
@@ -1,6 +1,8 @@
 // SYNTAX TEST "HLSL.sublime-syntax"
 
 
+// Comments
+
   // Comment!
 //^^^^^^^^^^^ comment.line.double-slash.hlsl
 
@@ -17,6 +19,9 @@
   Another line of comment! */
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.hlsl
 
+
+// Includes
+
   #include "file.fxh"
 //^^^^^^^^^^^^^^^^^^^ meta.preprocessor.include.hlsl
 //^^^^^^^^ keyword.control.preprocessor.include.hlsl
@@ -32,6 +37,9 @@
 //          ^^^^^^^^ string.quoted.other.lt-gt.include.hlsl
 //                  ^ punctuation.definition.string.end.hlsl
 
+
+// Cbuffer
+
   cbuffer BufferName : register(b0)
 //^^^^^^^ storage.type.buffer.hlsl
 //       ^^^^^^^^^^^^^^^^^^^^^^^^^^ -storage.type.buffer.hlsl
@@ -44,6 +52,9 @@
     float4 Float4Var;
 //  ^^^^^^ storage.type.vector.hlsl
   }
+
+
+// Swizzling
 
   float3 var1;
   float4 var2 = var1.xrgz;
@@ -64,8 +75,33 @@
 //                  ^^^^^^^^^^ variable.other.dot-access.hlsl
 
 
+// Macros
+
+  #define NAMESPACE_START(name) namespace name {
+//        ^^^^^^^^^^^^^^^ entity.name.function.hlsl
+//^^^^^^^^ -entity.name.function.hlsl
+//                       ^^^^^^^^^^^^^^^^^^^^^^^ -entity.name.function.hlsl
+//^^^^^^^^^^^^^^^^^^^^^^^^ -meta.function.parameters.hlsl
+//                             ^^^^^^^^^^^^^^^^^ -meta.function.parameters.hlsl
+//                        ^^^^^ meta.function.parameters.hlsl
+//                             ^^^^^^^^^^^^^^^^^ meta.function.hlsl
+
+//^ -meta.function.hlsl
+
+  #define NAMESPACE_END }
+//^^^^^^^ keyword.control.preprocessor.hlsl
+//       ^^^^^^^^^^^^^^ -keyword.control.preprocessor.hlsl
+//        ^^^^^^^^^^^^^ constant.other.hlsl
+//^^^^^^^^ -constant.other.hlsl
+//                     ^^ -constant.other.hlsl
+//^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.hlsl
+
+//^ -meta.preprocessor.hlsl
+
+
 // Everything below here should be removed at some point
 // I believe it is (or should be) redundant with tests in other files
+
 typedef struct
 //      ^ storage.type.struct.hlsl
 {


### PR DESCRIPTION
This should fix #47.