### PR TITLE
Small fixes around ifdef formatting

### DIFF
--- a/HLSL.sublime-syntax
+++ b/HLSL.sublime-syntax
@@ -507,7 +507,7 @@ contexts:
         - include: preprocessor_line_continuation
         - include: preprocessor_line_ending
 
-    - match: (#if[n]*def)(?:\s+)({{valid_variable}})
+    - match: (#\s*if[n]?def)(?:\s+)({{valid_variable}})
       captures:
         1: keyword.control.preprocessor.hlsl
         2: constant.other.hlsl


### PR DESCRIPTION
Like other preprocessor directives, you can have space between the # and
the rest of the directive, but I managed to miss handling that
specifically for ifdef and ifndef.  Noticed the new matching script was
breaking in core SRP headers because of it, so that should be fixed now.

Also noticed I accidentally set the n as 0 or more, rather than 0 or 1,
which meant that #ifnnnnnnnnnndef would be picked up as a proper
preprocessor directive.  Which it is not.