### PR TITLE
Fix whitespace issue with RW types

### DIFF
--- a/HLSL.sublime-syntax
+++ b/HLSL.sublime-syntax
@@ -149,7 +149,7 @@ contexts:
     - match: '{{texture_types}}'
       scope: storage.type.texture.hlsl
 
-    - match: '(globallycoherent)?(?:\s+)({{texture_rw_types}})'
+    - match: '(globallycoherent)?(?:\b\s*)({{texture_rw_types}})'
       captures:
         1: storage.modifier.hlsl
         2: storage.type.texture.hlsl
@@ -157,7 +157,7 @@ contexts:
     - match: '{{buffer_types}}'
       scope: storage.type.buffer.hlsl
 
-    - match: '(globallycoherent)?(?:\s+)({{buffer_rw_types}})'
+    - match: '(globallycoherent)?(?:\b\s*)({{buffer_rw_types}})'
       captures:
         1: storage.modifier.hlsl
         2: storage.type.buffer.hlsl
@@ -211,7 +211,7 @@ contexts:
 
 
   functions:
-    - match: (?:({{scalar_types}})|({{vector_types}})|({{matrix_types}})|({{texture_types}})|(globallycoherent)?(?:\s+)({{texture_rw_types}})|({{buffer_types}})|(globallycoherent)?(?:\s+)({{buffer_rw_types}})|(\b{{valid_variable}})\b)(?:\s+)(\b{{valid_variable}})(?:\s*)(?:\()
+    - match: (?:({{scalar_types}})|({{vector_types}})|({{matrix_types}})|({{texture_types}})|(globallycoherent)?(?:\b\s*)({{texture_rw_types}})|({{buffer_types}})|(globallycoherent)?(?:\b\s*)({{buffer_rw_types}})|(\b{{valid_variable}})\b)(?:\s+)(\b{{valid_variable}})(?:\s*)(?:\()
       captures:
         1: storage.type.scalar.hlsl
         2: storage.type.vector.hlsl


### PR DESCRIPTION
When I made globallycoherent an optional modifier, I accidentally didn't
make the whitespace between them optional.  This meant that without the
modifier, any RW type defined with no leading whitespace wasn't properly
scoped.  This should fix it by making the whitespace non-capture group
look for word boundary and then any amount of whitespace.